### PR TITLE
Verify oddities

### DIFF
--- a/NsbBridgePlayground.Bootstrap/Bootstrapper.cs
+++ b/NsbBridgePlayground.Bootstrap/Bootstrapper.cs
@@ -3,7 +3,11 @@ using NsbBridgePlayground.Common.Attributes;
 using NServiceBus;
 using System.Reflection;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Bootstrap;
+#else
 namespace NsbBridgePlayground.Bootstrap;
+#endif
 
 public class Bootstrapper
 {

--- a/NsbBridgePlayground.Bootstrap/Infrastructure/DbHelpers.cs
+++ b/NsbBridgePlayground.Bootstrap/Infrastructure/DbHelpers.cs
@@ -1,7 +1,11 @@
 ﻿using Microsoft.Data.SqlClient;
 using System.Data;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Bootstrap.Infrastructure;
+#else
 namespace NsbBridgePlayground.Bootstrap.Infrastructure;
+#endif
 
 public class DbHelpers
 {

--- a/NsbBridgePlayground.Bridge/appsettings.json
+++ b/NsbBridgePlayground.Bridge/appsettings.json
@@ -1,4 +1,5 @@
-﻿{
+﻿
+{
   "Logging": {
     "LogLevel": {
       "Default": "Debug",
@@ -8,7 +9,7 @@
     }
   },
   "ConnectionStrings": {
-    "Notifier": "Server=(localdb)\\MSSqlLocalDb;Initial Catalog=NsbBridgePlayground.Notifier;Integrated Security=true;Application Name=NsbBridgePlayground",
+    "Notifier": "Server=(localdb)\\ProjectsV13;Initial Catalog=NsbBridgePlayground.Notifier;Integrated Security=true;Application Name=NsbBridgePlayground",
     "Sender": "Server=(localdb)\\MSSqlLocalDb;Initial Catalog=NsbBridgePlayground.Sender;Integrated Security=true;Application Name=NsbBridgePlayground",
     "OrderProcessor": "Server=(localdb)\\MSSqlLocalDb;Initial Catalog=NsbBridgePlayground.OrderProcessor;Integrated Security=true;Application Name=NsbBridgePlayground",
     "Shipping": "Server=(localdb)\\MSSqlLocalDb;Initial Catalog=NsbBridgePlayground.Shipping;Integrated Security=true;Application Name=NsbBridgePlayground"

--- a/NsbBridgePlayground.Notifier/Handlers/OrderCreatedHandler.cs
+++ b/NsbBridgePlayground.Notifier/Handlers/OrderCreatedHandler.cs
@@ -2,7 +2,11 @@ using Microsoft.Extensions.Logging;
 using NsbBridgePlayground.Common.Messages.Events;
 using NServiceBus;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Notifier.Handlers;
+#else
 namespace NsbBridgePlayground.Notifier.Handlers;
+#endif
 
 internal class OrderCreatedHandler : IHandleMessages<OrderCreated>
 {

--- a/NsbBridgePlayground.Notifier/Program.cs
+++ b/NsbBridgePlayground.Notifier/Program.cs
@@ -1,22 +1,37 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+#if STANDALONE
+using NsbBridgePlayground.StandAlone.Bootstrap;
+using NsbBridgePlayground.StandAlone.Bootstrap.Infrastructure;
+#else
 using NsbBridgePlayground.Bootstrap;
 using NsbBridgePlayground.Bootstrap.Infrastructure;
+#endif
 using NsbBridgePlayground.Common;
 using NServiceBus;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Notifier;
+#else
 namespace NsbBridgePlayground.Notifier;
+#endif
 
 internal class Program
 {
+#if STANDALONE
+  private static readonly string ConnectionStringName = "NsbBridgePlayground";
+#else
+  private static readonly string ConnectionStringName = "Notifier";
+#endif
+
   public static async Task Main(string[] args)
   {
     var host = CreateHostBuilder(args)
       .Build();
 
     var config = host.Services.GetRequiredService<IConfiguration>();
-    await DbHelpers.EnsureDatabaseExists(config.GetConnectionString("Notifier"));
+    await DbHelpers.EnsureDatabaseExists(config.GetConnectionString(ConnectionStringName));
 
     await host.RunAsync();
   }
@@ -32,7 +47,7 @@ internal class Program
       .UseConsoleLifetime()
       .UseNServiceBus(ctx => {
 
-        var endpointConfig = Bootstrapper.Configure(Endpoints.Notifier, ctx.Configuration.GetConnectionString("Notifier"));
+        var endpointConfig = Bootstrapper.Configure(Endpoints.Notifier, ctx.Configuration.GetConnectionString(ConnectionStringName));
         return endpointConfig;
       });
 

--- a/NsbBridgePlayground.OrderProcessor/Handlers/CreateOrderHandler.cs
+++ b/NsbBridgePlayground.OrderProcessor/Handlers/CreateOrderHandler.cs
@@ -6,7 +6,11 @@ using NsbBridgePlayground.Common.Messages.Events;
 using NServiceBus;
 using NServiceBus.Persistence;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.OrderProcessor.Handlers;
+#else
 namespace NsbBridgePlayground.OrderProcessor.Handlers;
+#endif
 
 internal class CreateOrderHandler : IHandleMessages<CreateOrder>
 {

--- a/NsbBridgePlayground.OrderProcessor/Program.cs
+++ b/NsbBridgePlayground.OrderProcessor/Program.cs
@@ -1,22 +1,37 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+#if STANDALONE
+using NsbBridgePlayground.StandAlone.Bootstrap;
+using NsbBridgePlayground.StandAlone.Bootstrap.Infrastructure;
+#else
 using NsbBridgePlayground.Bootstrap;
 using NsbBridgePlayground.Bootstrap.Infrastructure;
+#endif
 using NsbBridgePlayground.Common;
 using NServiceBus;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.OrderProcessor;
+#else
 namespace NsbBridgePlayground.OrderProcessor;
+#endif
 
 internal class Program
 {
+#if STANDALONE
+  private static readonly string ConnectionStringName = "NsbBridgePlayground";
+#else
+  private static readonly string ConnectionStringName = "OrderProcessor";
+#endif
+  
   public static async Task Main(string[] args)
   {
     var host = CreateHostBuilder(args)
       .Build();
 
     var config = host.Services.GetRequiredService<IConfiguration>();
-    await DbHelpers.EnsureDatabaseExists(config.GetConnectionString("OrderProcessor"));
+    await DbHelpers.EnsureDatabaseExists(config.GetConnectionString(ConnectionStringName));
 
     await host.RunAsync();
   }
@@ -32,7 +47,7 @@ internal class Program
       .UseConsoleLifetime()
       .UseNServiceBus(ctx => {
 
-        var endpointConfig = Bootstrapper.Configure(Endpoints.OrderProcessor, ctx.Configuration.GetConnectionString("OrderProcessor"));
+        var endpointConfig = Bootstrapper.Configure(Endpoints.OrderProcessor, ctx.Configuration.GetConnectionString(ConnectionStringName));
         return endpointConfig;
       });
 

--- a/NsbBridgePlayground.Sender/Handlers/CreateOrderResponseHandler.cs
+++ b/NsbBridgePlayground.Sender/Handlers/CreateOrderResponseHandler.cs
@@ -2,7 +2,11 @@ using Microsoft.Extensions.Logging;
 using NsbBridgePlayground.Common.Messages;
 using NServiceBus;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Sender.Handlers;
+#else
 namespace NsbBridgePlayground.Sender.Handlers;
+#endif
 
 internal class CreateOrderResponseHandler : IHandleMessages<CreateOrderResponse>
 {

--- a/NsbBridgePlayground.Sender/Program.SendMessages.cs
+++ b/NsbBridgePlayground.Sender/Program.SendMessages.cs
@@ -2,7 +2,11 @@
 using NsbBridgePlayground.Common.Messages.Commands;
 using NServiceBus;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Sender;
+#else
 namespace NsbBridgePlayground.Sender;
+#endif
 
 internal partial class Program
 {

--- a/NsbBridgePlayground.Shipping/Handlers/OrderCreatedHandler.cs
+++ b/NsbBridgePlayground.Shipping/Handlers/OrderCreatedHandler.cs
@@ -2,7 +2,11 @@ using Microsoft.Extensions.Logging;
 using NsbBridgePlayground.Common.Messages.Events;
 using NServiceBus;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Shipping.Handlers;
+#else
 namespace NsbBridgePlayground.Shipping.Handlers;
+#endif
 
 internal class OrderCreatedHandler : IHandleMessages<OrderCreated>
 {

--- a/NsbBridgePlayground.Shipping/Program.cs
+++ b/NsbBridgePlayground.Shipping/Program.cs
@@ -1,21 +1,37 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+#if STANDALONE
+using NsbBridgePlayground.StandAlone.Bootstrap;
+using NsbBridgePlayground.StandAlone.Bootstrap.Infrastructure;
+#else
 using NsbBridgePlayground.Bootstrap;
 using NsbBridgePlayground.Bootstrap.Infrastructure;
+#endif
 using NsbBridgePlayground.Common;
 using NServiceBus;
 
+#if STANDALONE
+namespace NsbBridgePlayground.StandAlone.Shipping;
+#else
 namespace NsbBridgePlayground.Shipping;
+#endif
 
-internal class Program {
+internal class Program 
+{
+#if STANDALONE
+  private static readonly string ConnectionStringName = "NsbBridgePlayground";
+#else
+  private static readonly string ConnectionStringName = "Shipping";
+#endif
+
   public static async Task Main(string[] args)
   {
     var host = CreateHostBuilder(args)
       .Build();
 
     var config = host.Services.GetRequiredService<IConfiguration>();
-    await DbHelpers.EnsureDatabaseExists(config.GetConnectionString("Shipping"));
+    await DbHelpers.EnsureDatabaseExists(config.GetConnectionString(ConnectionStringName));
 
     await host.RunAsync();
   }
@@ -31,7 +47,7 @@ internal class Program {
       .UseConsoleLifetime()
       .UseNServiceBus(ctx => {
 
-        var endpointConfig = Bootstrapper.Configure(Endpoints.Shipping, ctx.Configuration.GetConnectionString("Shipping"));
+        var endpointConfig = Bootstrapper.Configure(Endpoints.Shipping, ctx.Configuration.GetConnectionString(ConnectionStringName));
         return endpointConfig;
       });
 

--- a/NsbBridgePlayground.sln
+++ b/NsbBridgePlayground.sln
@@ -47,6 +47,23 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Databases", "Databases", "{
 		databases\05_shipping.sql = databases\05_shipping.sql
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NotUsingBridge", "NotUsingBridge", "{053A3186-B58C-49B4-B3A6-5E651262C093}"
+	ProjectSection(SolutionItems) = preProject
+		StandAlone\appsettings.json = StandAlone\appsettings.json
+		databases\01_create_login.sql = databases\01_create_login.sql
+		StandAlone\02_database.sql = StandAlone\02_database.sql
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NsbBridgePlayground.StandAlone.Sender", "StandAlone\NsbBridgePlayground.StandAlone.Sender\NsbBridgePlayground.StandAlone.Sender.csproj", "{59AABFD4-1FDF-4B43-8AF8-B438F2CE87BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NsbBridgePlayground.StandAlone.Bootstrap", "StandAlone\NsbBridgePlayground.StandAlone.Bootstrap\NsbBridgePlayground.StandAlone.Bootstrap.csproj", "{ADD1D21B-452F-418B-AAF4-578DF70153C1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NsbBridgePlayground.StandAlone.OrderProcessor", "StandAlone\NsbBridgePlayground.StandAlone.OrderProcessor\NsbBridgePlayground.StandAlone.OrderProcessor.csproj", "{B1EF5C65-429C-4928-BE6F-10776882DF82}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NsbBridgePlayground.StandAlone.Notifier", "StandAlone\NsbBridgePlayground.StandAlone.Notifier\NsbBridgePlayground.StandAlone.Notifier.csproj", "{349B770C-DC12-4613-A4CB-05E26F2B55E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NsbBridgePlayground.StandAlone.Shipping", "StandAlone\NsbBridgePlayground.StandAlone.Shipping\NsbBridgePlayground.StandAlone.Shipping.csproj", "{3D7E2648-FAA7-41C9-ADAB-8860C340BF2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +101,26 @@ Global
 		{FFD337D5-FA98-40A0-8684-5FF66B261DC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FFD337D5-FA98-40A0-8684-5FF66B261DC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FFD337D5-FA98-40A0-8684-5FF66B261DC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59AABFD4-1FDF-4B43-8AF8-B438F2CE87BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59AABFD4-1FDF-4B43-8AF8-B438F2CE87BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59AABFD4-1FDF-4B43-8AF8-B438F2CE87BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59AABFD4-1FDF-4B43-8AF8-B438F2CE87BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADD1D21B-452F-418B-AAF4-578DF70153C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADD1D21B-452F-418B-AAF4-578DF70153C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADD1D21B-452F-418B-AAF4-578DF70153C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADD1D21B-452F-418B-AAF4-578DF70153C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1EF5C65-429C-4928-BE6F-10776882DF82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1EF5C65-429C-4928-BE6F-10776882DF82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1EF5C65-429C-4928-BE6F-10776882DF82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1EF5C65-429C-4928-BE6F-10776882DF82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{349B770C-DC12-4613-A4CB-05E26F2B55E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{349B770C-DC12-4613-A4CB-05E26F2B55E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{349B770C-DC12-4613-A4CB-05E26F2B55E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{349B770C-DC12-4613-A4CB-05E26F2B55E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D7E2648-FAA7-41C9-ADAB-8860C340BF2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D7E2648-FAA7-41C9-ADAB-8860C340BF2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D7E2648-FAA7-41C9-ADAB-8860C340BF2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D7E2648-FAA7-41C9-ADAB-8860C340BF2F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CCD4FB1C-650B-44F5-8079-B11C50723796} = {33563CBE-E6C2-478A-8FFF-691BC5B74FA0}
@@ -93,5 +130,10 @@ Global
 		{B81EC69D-9154-41B6-8A8C-F4EEEC225B52} = {D7885579-EB30-4844-B814-37A4E34EA44D}
 		{9ED8736B-6E4F-4D02-BF27-B5B30BC9F1EA} = {6BBDB0AD-378B-49C5-8F86-6977C8A41099}
 		{73C07FB6-E797-4147-9876-5B859C69471A} = {6BBDB0AD-378B-49C5-8F86-6977C8A41099}
+		{59AABFD4-1FDF-4B43-8AF8-B438F2CE87BD} = {053A3186-B58C-49B4-B3A6-5E651262C093}
+		{ADD1D21B-452F-418B-AAF4-578DF70153C1} = {053A3186-B58C-49B4-B3A6-5E651262C093}
+		{B1EF5C65-429C-4928-BE6F-10776882DF82} = {053A3186-B58C-49B4-B3A6-5E651262C093}
+		{349B770C-DC12-4613-A4CB-05E26F2B55E7} = {053A3186-B58C-49B4-B3A6-5E651262C093}
+		{3D7E2648-FAA7-41C9-ADAB-8860C340BF2F} = {053A3186-B58C-49B4-B3A6-5E651262C093}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ OrderProcessor --> Sender : ""CreateOrderResponse""
 
 OrderProcessor -[dotted]> Notifier : ""OrderCreated""
 OrderProcessor -[dotted]> Shipping : ""OrderCreated""
+
+@enduml
 ```
 
 ### Using the bridge
@@ -68,6 +70,8 @@ OrderProcessor -[#magenta,dashed]> Bridge : **(3)** ""CreateOrderResponse""
 Bridge -[#green,dotted]-> Notifier : **(4)** ""OrderCreated""
 Bridge -[#green,dotted]-> Shipping : **(4)** ""OrderCreated""
 Bridge -[#magenta,dotted]-> Sender : **(4)** ""CreateOrderResponse""
+
+@enduml
 ```
 
 ## Required Changes

--- a/StandAlone/02_database.sql
+++ b/StandAlone/02_database.sql
@@ -1,0 +1,196 @@
+USE master 
+
+DROP DATABASE IF EXISTS [NsbBridgePlayground.StandAlone];
+
+CREATE DATABASE [NsbBridgePlayground.StandAlone]
+GO
+
+USE [NsbBridgePlayground.StandAlone]
+
+/* 
+    Currently, in AWS RDS I cannot create a login and grant access from our network,
+    so first check if the expected login exists.
+*/    
+IF EXISTS
+(
+  SELECT name  
+    FROM master.sys.server_principals
+    WHERE name = 'docker'
+)
+BEGIN
+  CREATE USER [docker] FOR LOGIN [docker] WITH DEFAULT_SCHEMA=[dbo]
+  ALTER ROLE [db_datareader] ADD MEMBER [docker]
+  ALTER ROLE [db_datawriter] ADD MEMBER [docker]
+END
+GO
+/****** Object:  Schema [nsb]    Script Date: 20/06/2023 12:33:51 ******/
+CREATE SCHEMA [nsb]
+GO
+/****** Object:  Table [nsb].[audit]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[audit](
+	[Id] [uniqueidentifier] NOT NULL,
+	[CorrelationId] [varchar](255) NULL,
+	[ReplyToAddress] [varchar](255) NULL,
+	[Recoverable] [bit] NOT NULL,
+	[Expires] [datetime] NULL,
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[error]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[error](
+	[Id] [uniqueidentifier] NOT NULL,
+	[CorrelationId] [varchar](255) NULL,
+	[ReplyToAddress] [varchar](255) NULL,
+	[Recoverable] [bit] NOT NULL,
+	[Expires] [datetime] NULL,
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[Notifier]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[Notifier](
+	[Id] [uniqueidentifier] NOT NULL,
+	[CorrelationId] [varchar](255) NULL,
+	[ReplyToAddress] [varchar](255) NULL,
+	[Recoverable] [bit] NOT NULL,
+	[Expires] [datetime] NULL,
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[Notifier.Delayed]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[Notifier.Delayed](
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[Due] [datetime] NOT NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[OrderProcessor]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[OrderProcessor](
+	[Id] [uniqueidentifier] NOT NULL,
+	[CorrelationId] [varchar](255) NULL,
+	[ReplyToAddress] [varchar](255) NULL,
+	[Recoverable] [bit] NOT NULL,
+	[Expires] [datetime] NULL,
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[OrderProcessor.Delayed]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[OrderProcessor.Delayed](
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[Due] [datetime] NOT NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[Sender]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[Sender](
+	[Id] [uniqueidentifier] NOT NULL,
+	[CorrelationId] [varchar](255) NULL,
+	[ReplyToAddress] [varchar](255) NULL,
+	[Recoverable] [bit] NOT NULL,
+	[Expires] [datetime] NULL,
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[Sender.Delayed]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[Sender.Delayed](
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[Due] [datetime] NOT NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[Shipping]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[Shipping](
+	[Id] [uniqueidentifier] NOT NULL,
+	[CorrelationId] [varchar](255) NULL,
+	[ReplyToAddress] [varchar](255) NULL,
+	[Recoverable] [bit] NOT NULL,
+	[Expires] [datetime] NULL,
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[Shipping.Delayed]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[Shipping.Delayed](
+	[Headers] [nvarchar](max) NOT NULL,
+	[Body] [varbinary](max) NULL,
+	[Due] [datetime] NOT NULL,
+	[RowVersion] [bigint] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+/****** Object:  Table [nsb].[SubscriptionRouting]    Script Date: 20/06/2023 12:33:51 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [nsb].[SubscriptionRouting](
+	[QueueAddress] [nvarchar](200) NOT NULL,
+	[Endpoint] [nvarchar](200) NOT NULL,
+	[Topic] [nvarchar](200) NOT NULL,
+PRIMARY KEY CLUSTERED 
+(
+	[Endpoint] ASC,
+	[Topic] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/* Business data */
+CREATE TABLE [dbo].[Orders](
+    [Id] int IDENTITY(1, 1) NOT NULL PRIMARY KEY,
+    [UId] uniqueidentifier NOT NULL,
+    [Notes] nvarchar(max) NULL,
+    [CreatedAt] DATETIME2 NOT NULL
+    )
+GO

--- a/StandAlone/NsbBridgePlayground.StandAlone.Bootstrap/NsbBridgePlayground.StandAlone.Bootstrap.csproj
+++ b/StandAlone/NsbBridgePlayground.StandAlone.Bootstrap/NsbBridgePlayground.StandAlone.Bootstrap.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);STANDALONE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\NsbBridgePlayground.Bootstrap\Bootstrapper.cs">
+      <Link>Bootstrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NsbBridgePlayground.Bootstrap\Infrastructure\DbHelpers.cs">
+      <Link>Infrastructure\DbHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Persistence.Sql" Version="6.6.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\NsbBridgePlayground.Common\NsbBridgePlayground.Common.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/StandAlone/NsbBridgePlayground.StandAlone.Notifier/NsbBridgePlayground.StandAlone.Notifier.csproj
+++ b/StandAlone/NsbBridgePlayground.StandAlone.Notifier/NsbBridgePlayground.StandAlone.Notifier.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);STANDALONE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NsbBridgePlayground.StandAlone.Bootstrap\NsbBridgePlayground.StandAlone.Bootstrap.csproj" />
+    <ProjectReference Include="..\..\NsbBridgePlayground.Common\NsbBridgePlayground.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\NsbBridgePlayground.Notifier\Handlers\OrderCreatedHandler.cs">
+      <Link>Handlers\OrderCreatedHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NsbBridgePlayground.Notifier\Program.cs">
+      <Link>Program.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\appsettings.json">
+      <Link>appsettings.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+</Project>

--- a/StandAlone/NsbBridgePlayground.StandAlone.OrderProcessor/NsbBridgePlayground.StandAlone.OrderProcessor.csproj
+++ b/StandAlone/NsbBridgePlayground.StandAlone.OrderProcessor/NsbBridgePlayground.StandAlone.OrderProcessor.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);STANDALONE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Dapper" Version="2.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NsbBridgePlayground.StandAlone.Bootstrap\NsbBridgePlayground.StandAlone.Bootstrap.csproj" />
+    <ProjectReference Include="..\..\NsbBridgePlayground.Common\NsbBridgePlayground.Common.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="..\..\NsbBridgePlayground.OrderProcessor\Handlers\CreateOrderHandler.cs">
+      <Link>Handlers\CreateOrderHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NsbBridgePlayground.OrderProcessor\Program.cs">
+      <Link>Program.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\appsettings.json">
+      <Link>appsettings.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+</Project>

--- a/StandAlone/NsbBridgePlayground.StandAlone.Sender/NsbBridgePlayground.StandAlone.Sender.csproj
+++ b/StandAlone/NsbBridgePlayground.StandAlone.Sender/NsbBridgePlayground.StandAlone.Sender.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);STANDALONE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Lorem.Universal.Net" Version="4.0.80"/>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.*"/>
+    <PackageReference Include="Seq.Extensions.Logging" Version="6.1.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NsbBridgePlayground.StandAlone.Bootstrap\NsbBridgePlayground.StandAlone.Bootstrap.csproj" />
+    <ProjectReference Include="..\..\NsbBridgePlayground.Common\NsbBridgePlayground.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\NsbBridgePlayground.Sender\Handlers\CreateOrderResponseHandler.cs">
+      <Link>Handlers\CreateOrderResponseHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NsbBridgePlayground.Sender\Program.cs">
+      <Link>Program.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NsbBridgePlayground.Sender\Program.SendMessages.cs">
+      <Link>Program.SendMessages.cs</Link>
+      <DependentUpon>Program.cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\appsettings.json">
+      <Link>appsettings.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+</Project>

--- a/StandAlone/NsbBridgePlayground.StandAlone.Shipping/NsbBridgePlayground.StandAlone.Shipping.csproj
+++ b/StandAlone/NsbBridgePlayground.StandAlone.Shipping/NsbBridgePlayground.StandAlone.Shipping.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DefineConstants>$(DefineConstants);STANDALONE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NsbBridgePlayground.StandAlone.Bootstrap\NsbBridgePlayground.StandAlone.Bootstrap.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\NsbBridgePlayground.Shipping\Handlers\OrderCreatedHandler.cs">
+      <Link>Handlers\OrderCreatedHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\NsbBridgePlayground.Shipping\Program.cs">
+      <Link>Program.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\appsettings.json">
+      <Link>appsettings.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/StandAlone/appsettings.json
+++ b/StandAlone/appsettings.json
@@ -1,0 +1,21 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information",
+      "NServiceBus": "Error"
+    }
+  },
+  "ConnectionStrings": {
+    "NsbBridgePlayground": "Server=(localdb)\\MSSqlLocalDb;Initial Catalog=NsbBridgePlayground.StandAlone;Integrated Security=true;Application Name=NsbBridgePlayground"
+  },
+  "Seq": {
+    "ServerUrl": "http://localhost:5341",
+    "ApiKey": "",
+    "MinimumLevel": "Info",
+    "LevelOverride": {
+      "Microsoft": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
Create a parallel set of endpoints all using the same database, so that there's no need for the bridge, and look at NServiceBus headers in this scenario.

Also, update the standard scenario so that two SQL Server instances are used: this causes the application to fail at some point, because of the manipulations of headers applied by the bridge.